### PR TITLE
Update schema to 6.4 and enable new bg image feature

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://schemas.wp.org/wp/6.3/theme.json",
   "customTemplates": [
     {
       "name": "blank",
@@ -11,6 +10,9 @@
     }
   ],
   "settings": {
+    "background": {
+      "backgroundImage": true
+    },
     "appearanceTools": true,
     "blocks": {
       "core/cover": {
@@ -772,5 +774,6 @@
       "title": "Footer"
     }
   ],
-  "version": 2
+  "version": 2,
+  "$schema": "https://schemas.wp.org/wp/6.4/theme.json"
 }


### PR DESCRIPTION
https://make.wordpress.org/core/2023/10/17/miscellaneous-editor-changes-in-wordpress-6-4/#how-to-add-backgroundimage-support-to-a-theme

6.4 added support for the background image. This enables the feature.

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1203895219649773/1206490244484700)
