### PR TITLE
Remove is-sticky header class

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
 <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center","level":1} -->

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,65 +1,45 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"
-  style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
-  <!-- wp:heading {"textAlign":"center","level":1} -->
+<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center","level":1} -->
   <h1 class="wp-block-heading has-text-align-center">404 <br>Page not found</h1>
   <!-- /wp:heading -->
 
   <!-- wp:paragraph {"align":"center"} -->
   <p class="has-text-align-center">We're sorry, but it looks like the page you're looking for can not be found.</p>
-  <!-- /wp:paragraph -->
-</div>
-<!-- /wp:group -->
+  <!-- /wp:paragraph --></div>
+  <!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained","contentSize":"900px"}} -->
-<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)">
-  <!-- wp:columns {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
-  <div class="wp-block-columns" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
-    <!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
-    <div class="wp-block-column"
-      style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
-      <!-- wp:group {"layout":{"type":"constrained"}} -->
-      <div class="wp-block-group"><!-- wp:image {"id":40,"sizeSlug":"large","linkDestination":"none"} -->
-        <figure class="wp-block-image size-large"><img src="/wp-content/themes/kindling/assets/images/placeholder.png"
-            alt="" class="wp-image-40" /></figure>
-        <!-- /wp:image -->
+  <!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained","contentSize":"900px"}} -->
+  <div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+  <div class="wp-block-columns" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
+  <div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:group {"layout":{"type":"constrained"}} -->
+  <div class="wp-block-group"><!-- wp:image {"id":40,"sizeSlug":"large","linkDestination":"none"} -->
+  <figure class="wp-block-image size-large"><img src="/wp-content/themes/kindling/assets/images/placeholder.png" alt="" class="wp-image-40"/></figure>
+  <!-- /wp:image -->
 
-        <!-- wp:buttons -->
-        <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-fill"} -->
-          <div class="wp-block-button is-style-fill"><a class="wp-block-button__link wp-element-button" href="/">Read
-              More</a></div>
-          <!-- /wp:button -->
-        </div>
-        <!-- /wp:buttons -->
-      </div>
-      <!-- /wp:group -->
-    </div>
-    <!-- /wp:column -->
+  <!-- wp:buttons -->
+  <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-fill"} -->
+  <div class="wp-block-button is-style-fill"><a class="wp-block-button__link wp-element-button" href="/">Read More</a></div>
+  <!-- /wp:button --></div>
+  <!-- /wp:buttons --></div>
+  <!-- /wp:group --></div>
+  <!-- /wp:column -->
 
-    <!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
-    <div class="wp-block-column"
-      style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
-      <!-- wp:group {"layout":{"type":"constrained"}} -->
-      <div class="wp-block-group"><!-- wp:image {"id":40,"sizeSlug":"large","linkDestination":"none"} -->
-        <figure class="wp-block-image size-large"><img src="/wp-content/themes/kindling/assets/images/placeholder.png"
-            alt="" class="wp-image-40" /></figure>
-        <!-- /wp:image -->
+  <!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
+  <div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:group {"layout":{"type":"constrained"}} -->
+  <div class="wp-block-group"><!-- wp:image {"id":40,"sizeSlug":"large","linkDestination":"none"} -->
+  <figure class="wp-block-image size-large"><img src="/wp-content/themes/kindling/assets/images/placeholder.png" alt="" class="wp-image-40"/></figure>
+  <!-- /wp:image -->
 
-        <!-- wp:buttons -->
-        <div class="wp-block-buttons"><!-- wp:button -->
-          <div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/">Read More</a></div>
-          <!-- /wp:button -->
-        </div>
-        <!-- /wp:buttons -->
-      </div>
-      <!-- /wp:group -->
-    </div>
-    <!-- /wp:column -->
-  </div>
-  <!-- /wp:columns -->
-</div>
-<!-- /wp:group -->
+  <!-- wp:buttons -->
+  <div class="wp-block-buttons"><!-- wp:button -->
+  <div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/">Read More</a></div>
+  <!-- /wp:button --></div>
+  <!-- /wp:buttons --></div>
+  <!-- /wp:group --></div>
+  <!-- /wp:column --></div>
+  <!-- /wp:columns --></div>
+  <!-- /wp:group -->
 
-<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->
+  <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,45 +1,65 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:heading {"textAlign":"center","level":1} -->
+<div class="wp-block-group"
+  style="padding-top:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--50)">
+  <!-- wp:heading {"textAlign":"center","level":1} -->
   <h1 class="wp-block-heading has-text-align-center">404 <br>Page not found</h1>
   <!-- /wp:heading -->
 
   <!-- wp:paragraph {"align":"center"} -->
   <p class="has-text-align-center">We're sorry, but it looks like the page you're looking for can not be found.</p>
-  <!-- /wp:paragraph --></div>
-  <!-- /wp:group -->
+  <!-- /wp:paragraph -->
+</div>
+<!-- /wp:group -->
 
-  <!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained","contentSize":"900px"}} -->
-  <div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
-  <div class="wp-block-columns" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
-  <div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:group {"layout":{"type":"constrained"}} -->
-  <div class="wp-block-group"><!-- wp:image {"id":40,"sizeSlug":"large","linkDestination":"none"} -->
-  <figure class="wp-block-image size-large"><img src="/wp-content/themes/kindling/assets/images/placeholder.png" alt="" class="wp-image-40"/></figure>
-  <!-- /wp:image -->
+<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained","contentSize":"900px"}} -->
+<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)">
+  <!-- wp:columns {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}}} -->
+  <div class="wp-block-columns" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
+    <!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
+    <div class="wp-block-column"
+      style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+      <!-- wp:group {"layout":{"type":"constrained"}} -->
+      <div class="wp-block-group"><!-- wp:image {"id":40,"sizeSlug":"large","linkDestination":"none"} -->
+        <figure class="wp-block-image size-large"><img src="/wp-content/themes/kindling/assets/images/placeholder.png"
+            alt="" class="wp-image-40" /></figure>
+        <!-- /wp:image -->
 
-  <!-- wp:buttons -->
-  <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-fill"} -->
-  <div class="wp-block-button is-style-fill"><a class="wp-block-button__link wp-element-button" href="/">Read More</a></div>
-  <!-- /wp:button --></div>
-  <!-- /wp:buttons --></div>
-  <!-- /wp:group --></div>
-  <!-- /wp:column -->
+        <!-- wp:buttons -->
+        <div class="wp-block-buttons"><!-- wp:button {"className":"is-style-fill"} -->
+          <div class="wp-block-button is-style-fill"><a class="wp-block-button__link wp-element-button" href="/">Read
+              More</a></div>
+          <!-- /wp:button -->
+        </div>
+        <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:group -->
+    </div>
+    <!-- /wp:column -->
 
-  <!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
-  <div class="wp-block-column" style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)"><!-- wp:group {"layout":{"type":"constrained"}} -->
-  <div class="wp-block-group"><!-- wp:image {"id":40,"sizeSlug":"large","linkDestination":"none"} -->
-  <figure class="wp-block-image size-large"><img src="/wp-content/themes/kindling/assets/images/placeholder.png" alt="" class="wp-image-40"/></figure>
-  <!-- /wp:image -->
+    <!-- wp:column {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","right":"var:preset|spacing|30","bottom":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
+    <div class="wp-block-column"
+      style="padding-top:var(--wp--preset--spacing--30);padding-right:var(--wp--preset--spacing--30);padding-bottom:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30)">
+      <!-- wp:group {"layout":{"type":"constrained"}} -->
+      <div class="wp-block-group"><!-- wp:image {"id":40,"sizeSlug":"large","linkDestination":"none"} -->
+        <figure class="wp-block-image size-large"><img src="/wp-content/themes/kindling/assets/images/placeholder.png"
+            alt="" class="wp-image-40" /></figure>
+        <!-- /wp:image -->
 
-  <!-- wp:buttons -->
-  <div class="wp-block-buttons"><!-- wp:button -->
-  <div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/">Read More</a></div>
-  <!-- /wp:button --></div>
-  <!-- /wp:buttons --></div>
-  <!-- /wp:group --></div>
-  <!-- /wp:column --></div>
-  <!-- /wp:columns --></div>
-  <!-- /wp:group -->
+        <!-- wp:buttons -->
+        <div class="wp-block-buttons"><!-- wp:button -->
+          <div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="/">Read More</a></div>
+          <!-- /wp:button -->
+        </div>
+        <!-- /wp:buttons -->
+      </div>
+      <!-- /wp:group -->
+    </div>
+    <!-- /wp:column -->
+  </div>
+  <!-- /wp:columns -->
+</div>
+<!-- /wp:group -->
 
-  <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->
+<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:group {"align":"full","className":"wp-block-hero-default px-4 py-16 mt-0 ","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wp-block-hero-default px-4 py-16 mt-0"><!-- wp:query-title {"type":"archive","level":2,"showPrefix":false} /-->

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,39 +1,46 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:group {"align":"full","className":"wp-block-hero-default px-4 py-16 mt-0 ","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull wp-block-hero-default px-4 py-16 mt-0"><!-- wp:query-title {"type":"archive","level":2,"showPrefix":false} /-->
+<div class="wp-block-group alignfull wp-block-hero-default px-4 py-16 mt-0">
+  <!-- wp:query-title {"type":"archive","level":2,"showPrefix":false} /-->
 
-<!-- wp:term-description /--></div>
+  <!-- wp:term-description /-->
+</div>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:columns {"className":"wp-block-query"} -->
-<div class="wp-block-columns wp-block-query"><!-- wp:post-template -->
-<!-- wp:columns -->
-<div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
-<div class="wp-block-column" style="flex-basis:100%"><!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+  <div class="wp-block-columns wp-block-query"><!-- wp:post-template -->
+    <!-- wp:columns -->
+    <div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
+      <div class="wp-block-column" style="flex-basis:100%">
+        <!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
 
-<!-- wp:post-title {"isLink":true} /-->
+        <!-- wp:post-title {"isLink":true} /-->
 
-<!-- wp:post-excerpt {"moreText":"Read More"} /--></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->
-<!-- /wp:post-template -->
+        <!-- wp:post-excerpt {"moreText":"Read More"} /-->
+      </div>
+      <!-- /wp:column -->
+    </div>
+    <!-- /wp:columns -->
+    <!-- /wp:post-template -->
 
-<!-- wp:query-pagination {"paginationArrow":"chevron"} -->
-<!-- wp:query-pagination-previous {"label":" "} /-->
+    <!-- wp:query-pagination {"paginationArrow":"chevron"} -->
+    <!-- wp:query-pagination-previous {"label":" "} /-->
 
-<!-- wp:query-pagination-numbers /-->
+    <!-- wp:query-pagination-numbers /-->
 
-<!-- wp:query-pagination-next {"label":" "} /-->
-<!-- /wp:query-pagination -->
+    <!-- wp:query-pagination-next {"label":" "} /-->
+    <!-- /wp:query-pagination -->
 
-<!-- wp:query-no-results -->
-<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-<p></p>
-<!-- /wp:paragraph -->
-<!-- /wp:query-no-results --></div>
-<!-- /wp:columns --></div>
+    <!-- wp:query-no-results -->
+    <!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+    <p></p>
+    <!-- /wp:paragraph -->
+    <!-- /wp:query-no-results -->
+  </div>
+  <!-- /wp:columns -->
+</div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/archive.html
+++ b/templates/archive.html
@@ -1,46 +1,39 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
 
 <!-- wp:group {"align":"full","className":"wp-block-hero-default px-4 py-16 mt-0 ","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull wp-block-hero-default px-4 py-16 mt-0">
-  <!-- wp:query-title {"type":"archive","level":2,"showPrefix":false} /-->
+<div class="wp-block-group alignfull wp-block-hero-default px-4 py-16 mt-0"><!-- wp:query-title {"type":"archive","level":2,"showPrefix":false} /-->
 
-  <!-- wp:term-description /-->
-</div>
+<!-- wp:term-description /--></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:columns {"className":"wp-block-query"} -->
-  <div class="wp-block-columns wp-block-query"><!-- wp:post-template -->
-    <!-- wp:columns -->
-    <div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
-      <div class="wp-block-column" style="flex-basis:100%">
-        <!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+<div class="wp-block-columns wp-block-query"><!-- wp:post-template -->
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
+<div class="wp-block-column" style="flex-basis:100%"><!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
 
-        <!-- wp:post-title {"isLink":true} /-->
+<!-- wp:post-title {"isLink":true} /-->
 
-        <!-- wp:post-excerpt {"moreText":"Read More"} /-->
-      </div>
-      <!-- /wp:column -->
-    </div>
-    <!-- /wp:columns -->
-    <!-- /wp:post-template -->
+<!-- wp:post-excerpt {"moreText":"Read More"} /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+<!-- /wp:post-template -->
 
-    <!-- wp:query-pagination {"paginationArrow":"chevron"} -->
-    <!-- wp:query-pagination-previous {"label":" "} /-->
+<!-- wp:query-pagination {"paginationArrow":"chevron"} -->
+<!-- wp:query-pagination-previous {"label":" "} /-->
 
-    <!-- wp:query-pagination-numbers /-->
+<!-- wp:query-pagination-numbers /-->
 
-    <!-- wp:query-pagination-next {"label":" "} /-->
-    <!-- /wp:query-pagination -->
+<!-- wp:query-pagination-next {"label":" "} /-->
+<!-- /wp:query-pagination -->
 
-    <!-- wp:query-no-results -->
-    <!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-    <p></p>
-    <!-- /wp:paragraph -->
-    <!-- /wp:query-no-results -->
-  </div>
-  <!-- /wp:columns -->
-</div>
+<!-- wp:query-no-results -->
+<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+<p></p>
+<!-- /wp:paragraph -->
+<!-- /wp:query-no-results --></div>
+<!-- /wp:columns --></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -1,11 +1,11 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
-  <!-- wp:group {"layout":{"type":"constrained"}} -->
-  <div class="wp-block-group"><!-- wp:shortcode -->[woocommerce_cart]<!-- /wp:shortcode --></div>
-  <!-- /wp:group -->
-</main>
+				<!-- wp:group {"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group"><!-- wp:shortcode -->[woocommerce_cart]<!-- /wp:shortcode --></div>
+				<!-- /wp:group -->
+			</main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/cart.html
+++ b/templates/cart.html
@@ -1,11 +1,11 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
-				<!-- wp:group {"layout":{"type":"constrained"}} -->
-				<div class="wp-block-group"><!-- wp:shortcode -->[woocommerce_cart]<!-- /wp:shortcode --></div>
-				<!-- /wp:group -->
-			</main>
+  <!-- wp:group {"layout":{"type":"constrained"}} -->
+  <div class="wp-block-group"><!-- wp:shortcode -->[woocommerce_cart]<!-- /wp:shortcode --></div>
+  <!-- /wp:group -->
+</main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -1,11 +1,11 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
-  <!-- wp:group {"layout":{"type":"constrained"}} -->
-  <div class="wp-block-group"><!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode --></div>
-  <!-- /wp:group -->
-</main>
+				<!-- wp:group {"layout":{"type":"constrained"}} -->
+				<div class="wp-block-group"><!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode --></div>
+				<!-- /wp:group -->
+			</main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">

--- a/templates/checkout.html
+++ b/templates/checkout.html
@@ -1,11 +1,11 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group">
-				<!-- wp:group {"layout":{"type":"constrained"}} -->
-				<div class="wp-block-group"><!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode --></div>
-				<!-- /wp:group -->
-			</main>
+  <!-- wp:group {"layout":{"type":"constrained"}} -->
+  <div class="wp-block-group"><!-- wp:shortcode -->[woocommerce_checkout]<!-- /wp:shortcode --></div>
+  <!-- /wp:group -->
+</main>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:group {"templateLock":"contentOnly","align":"full","className":"wp-block-hero-default py-16  mt-0","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wp-block-hero-default py-16 mt-0"><!-- wp:heading {"level":1} -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,66 +1,57 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
 
 <!-- wp:group {"templateLock":"contentOnly","align":"full","className":"wp-block-hero-default py-16  mt-0","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wp-block-hero-default py-16 mt-0"><!-- wp:heading {"level":1} -->
   <h1 class="wp-block-heading">News</h1>
-  <!-- /wp:heading -->
-</div>
-<!-- /wp:group -->
+  <!-- /wp:heading --></div>
+  <!-- /wp:group -->
 
-<!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:columns -->
+  <!-- wp:group {"layout":{"type":"constrained"}} -->
+  <div class="wp-block-group"><!-- wp:columns -->
   <div class="wp-block-columns"><!-- wp:column {"width":"25%"} -->
-    <div class="wp-block-column" style="flex-basis:25%"><!-- wp:heading {"level":3,"fontSize":"medium-large"} -->
-      <h3 class="wp-block-heading has-medium-large-font-size">Categories</h3>
-      <!-- /wp:heading -->
+  <div class="wp-block-column" style="flex-basis:25%"><!-- wp:heading {"level":3,"fontSize":"medium-large"} -->
+  <h3 class="wp-block-heading has-medium-large-font-size">Categories</h3>
+  <!-- /wp:heading -->
 
-      <!-- wp:categories /-->
-    </div>
-    <!-- /wp:column -->
+  <!-- wp:categories /--></div>
+  <!-- /wp:column -->
 
-    <!-- wp:column {"width":"75%"} -->
-    <div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading -->
-      <h2 class="wp-block-heading">Posts</h2>
-      <!-- /wp:heading -->
+  <!-- wp:column {"width":"75%"} -->
+  <div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading -->
+  <h2 class="wp-block-heading">Posts</h2>
+  <!-- /wp:heading -->
 
-      <!-- wp:query {"queryId":0,"query":{"perPage":"12","pages":"10","offset":0,"postType":"post","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]}} -->
-      <div class="wp-block-query"><!-- wp:post-template {"layout":{"type":"grid","columnCount":3}} -->
-        <!-- wp:columns -->
-        <div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
-          <div class="wp-block-column" style="flex-basis:100%">
-            <!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+  <!-- wp:query {"queryId":0,"query":{"perPage":"12","pages":"10","offset":0,"postType":"post","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]}} -->
+  <div class="wp-block-query"><!-- wp:post-template {"layout":{"type":"grid","columnCount":3}} -->
+  <!-- wp:columns -->
+  <div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
+  <div class="wp-block-column" style="flex-basis:100%"><!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
 
-            <!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|navy"}}}}} /-->
+  <!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|navy"}}}}} /-->
 
-            <!-- wp:post-title {"isLink":true} /-->
+  <!-- wp:post-title {"isLink":true} /-->
 
-            <!-- wp:post-excerpt {"moreText":"Read More"} /-->
-          </div>
-          <!-- /wp:column -->
-        </div>
-        <!-- /wp:columns -->
-        <!-- /wp:post-template -->
-
-        <!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
-        <!-- wp:query-pagination-previous {"label":" "} /-->
-
-        <!-- wp:query-pagination-numbers /-->
-
-        <!-- wp:query-pagination-next {"label":" "} /-->
-        <!-- /wp:query-pagination -->
-
-        <!-- wp:query-no-results -->
-        <!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-        <p></p>
-        <!-- /wp:paragraph -->
-        <!-- /wp:query-no-results -->
-      </div>
-      <!-- /wp:query -->
-    </div>
-    <!-- /wp:column -->
-  </div>
+  <!-- wp:post-excerpt {"moreText":"Read More"} /--></div>
+  <!-- /wp:column --></div>
   <!-- /wp:columns -->
-</div>
-<!-- /wp:group -->
+  <!-- /wp:post-template -->
 
-<!-- wp:template-part {"slug":"footer"} /-->
+  <!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
+  <!-- wp:query-pagination-previous {"label":" "} /-->
+
+  <!-- wp:query-pagination-numbers /-->
+
+  <!-- wp:query-pagination-next {"label":" "} /-->
+  <!-- /wp:query-pagination -->
+
+  <!-- wp:query-no-results -->
+  <!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+  <p></p>
+  <!-- /wp:paragraph -->
+  <!-- /wp:query-no-results --></div>
+  <!-- /wp:query --></div>
+  <!-- /wp:column --></div>
+  <!-- /wp:columns --></div>
+  <!-- /wp:group -->
+
+  <!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,57 +1,66 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:group {"templateLock":"contentOnly","align":"full","className":"wp-block-hero-default py-16  mt-0","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wp-block-hero-default py-16 mt-0"><!-- wp:heading {"level":1} -->
   <h1 class="wp-block-heading">News</h1>
-  <!-- /wp:heading --></div>
-  <!-- /wp:group -->
+  <!-- /wp:heading -->
+</div>
+<!-- /wp:group -->
 
-  <!-- wp:group {"layout":{"type":"constrained"}} -->
-  <div class="wp-block-group"><!-- wp:columns -->
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"><!-- wp:columns -->
   <div class="wp-block-columns"><!-- wp:column {"width":"25%"} -->
-  <div class="wp-block-column" style="flex-basis:25%"><!-- wp:heading {"level":3,"fontSize":"medium-large"} -->
-  <h3 class="wp-block-heading has-medium-large-font-size">Categories</h3>
-  <!-- /wp:heading -->
+    <div class="wp-block-column" style="flex-basis:25%"><!-- wp:heading {"level":3,"fontSize":"medium-large"} -->
+      <h3 class="wp-block-heading has-medium-large-font-size">Categories</h3>
+      <!-- /wp:heading -->
 
-  <!-- wp:categories /--></div>
-  <!-- /wp:column -->
+      <!-- wp:categories /-->
+    </div>
+    <!-- /wp:column -->
 
-  <!-- wp:column {"width":"75%"} -->
-  <div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading -->
-  <h2 class="wp-block-heading">Posts</h2>
-  <!-- /wp:heading -->
+    <!-- wp:column {"width":"75%"} -->
+    <div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading -->
+      <h2 class="wp-block-heading">Posts</h2>
+      <!-- /wp:heading -->
 
-  <!-- wp:query {"queryId":0,"query":{"perPage":"12","pages":"10","offset":0,"postType":"post","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]}} -->
-  <div class="wp-block-query"><!-- wp:post-template {"layout":{"type":"grid","columnCount":3}} -->
-  <!-- wp:columns -->
-  <div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
-  <div class="wp-block-column" style="flex-basis:100%"><!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+      <!-- wp:query {"queryId":0,"query":{"perPage":"12","pages":"10","offset":0,"postType":"post","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]}} -->
+      <div class="wp-block-query"><!-- wp:post-template {"layout":{"type":"grid","columnCount":3}} -->
+        <!-- wp:columns -->
+        <div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
+          <div class="wp-block-column" style="flex-basis:100%">
+            <!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
 
-  <!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|navy"}}}}} /-->
+            <!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|navy"}}}}} /-->
 
-  <!-- wp:post-title {"isLink":true} /-->
+            <!-- wp:post-title {"isLink":true} /-->
 
-  <!-- wp:post-excerpt {"moreText":"Read More"} /--></div>
-  <!-- /wp:column --></div>
+            <!-- wp:post-excerpt {"moreText":"Read More"} /-->
+          </div>
+          <!-- /wp:column -->
+        </div>
+        <!-- /wp:columns -->
+        <!-- /wp:post-template -->
+
+        <!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
+        <!-- wp:query-pagination-previous {"label":" "} /-->
+
+        <!-- wp:query-pagination-numbers /-->
+
+        <!-- wp:query-pagination-next {"label":" "} /-->
+        <!-- /wp:query-pagination -->
+
+        <!-- wp:query-no-results -->
+        <!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+        <p></p>
+        <!-- /wp:paragraph -->
+        <!-- /wp:query-no-results -->
+      </div>
+      <!-- /wp:query -->
+    </div>
+    <!-- /wp:column -->
+  </div>
   <!-- /wp:columns -->
-  <!-- /wp:post-template -->
+</div>
+<!-- /wp:group -->
 
-  <!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
-  <!-- wp:query-pagination-previous {"label":" "} /-->
-
-  <!-- wp:query-pagination-numbers /-->
-
-  <!-- wp:query-pagination-next {"label":" "} /-->
-  <!-- /wp:query-pagination -->
-
-  <!-- wp:query-no-results -->
-  <!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-  <p></p>
-  <!-- /wp:paragraph -->
-  <!-- /wp:query-no-results --></div>
-  <!-- /wp:query --></div>
-  <!-- /wp:column --></div>
-  <!-- /wp:columns --></div>
-  <!-- /wp:group -->
-
-  <!-- wp:template-part {"slug":"footer"} /-->
+<!-- wp:template-part {"slug":"footer"} /-->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:group {"templateLock":"contentOnly","align":"full","className":"wp-block-hero-default py-16  mt-0","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wp-block-hero-default py-16 mt-0"><!-- wp:heading {"level":1} -->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,58 +1,49 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
 
 <!-- wp:group {"templateLock":"contentOnly","align":"full","className":"wp-block-hero-default py-16  mt-0","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wp-block-hero-default py-16 mt-0"><!-- wp:heading {"level":1} -->
-  <h1 class="wp-block-heading">News</h1>
-  <!-- /wp:heading -->
-</div>
+<h1 class="wp-block-heading">News</h1>
+<!-- /wp:heading --></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:columns -->
-  <div class="wp-block-columns"><!-- wp:column {"width":"25%"} -->
-    <div class="wp-block-column" style="flex-basis:25%"><!-- wp:categories /--></div>
-    <!-- /wp:column -->
+<div class="wp-block-columns"><!-- wp:column {"width":"25%"} -->
+<div class="wp-block-column" style="flex-basis:25%"><!-- wp:categories /--></div>
+<!-- /wp:column -->
 
-    <!-- wp:column {"width":"75%"} -->
-    <div class="wp-block-column" style="flex-basis:75%">
-      <!-- wp:query {"queryId":0,"query":{"perPage":"12","pages":"10","offset":0,"postType":"post","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]},"displayLayout":{"type":"flex","columns":3}} -->
-      <div class="wp-block-query"><!-- wp:post-template -->
-        <!-- wp:columns -->
-        <div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
-          <div class="wp-block-column" style="flex-basis:100%">
-            <!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+<!-- wp:column {"width":"75%"} -->
+<div class="wp-block-column" style="flex-basis:75%"><!-- wp:query {"queryId":0,"query":{"perPage":"12","pages":"10","offset":0,"postType":"post","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]},"displayLayout":{"type":"flex","columns":3}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
+<div class="wp-block-column" style="flex-basis:100%"><!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
 
-            <!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|navy"}}}}} /-->
+<!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|navy"}}}}} /-->
 
-            <!-- wp:post-title {"isLink":true} /-->
+<!-- wp:post-title {"isLink":true} /-->
 
-            <!-- wp:post-excerpt {"moreText":"Read More"} /-->
-          </div>
-          <!-- /wp:column -->
-        </div>
-        <!-- /wp:columns -->
-        <!-- /wp:post-template -->
+<!-- wp:post-excerpt {"moreText":"Read More"} /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+<!-- /wp:post-template -->
 
-        <!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
-        <!-- wp:query-pagination-previous {"label":" "} /-->
+<!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:query-pagination-previous {"label":" "} /-->
 
-        <!-- wp:query-pagination-numbers /-->
+<!-- wp:query-pagination-numbers /-->
 
-        <!-- wp:query-pagination-next {"label":" "} /-->
-        <!-- /wp:query-pagination -->
+<!-- wp:query-pagination-next {"label":" "} /-->
+<!-- /wp:query-pagination -->
 
-        <!-- wp:query-no-results -->
-        <!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-        <p></p>
-        <!-- /wp:paragraph -->
-        <!-- /wp:query-no-results -->
-      </div>
-      <!-- /wp:query -->
-    </div>
-    <!-- /wp:column -->
-  </div>
-  <!-- /wp:columns -->
-</div>
+<!-- wp:query-no-results -->
+<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+<p></p>
+<!-- /wp:paragraph -->
+<!-- /wp:query-no-results --></div>
+<!-- /wp:query --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,49 +1,58 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:group {"templateLock":"contentOnly","align":"full","className":"wp-block-hero-default py-16  mt-0","layout":{"type":"constrained"}} -->
 <div class="wp-block-group alignfull wp-block-hero-default py-16 mt-0"><!-- wp:heading {"level":1} -->
-<h1 class="wp-block-heading">News</h1>
-<!-- /wp:heading --></div>
+  <h1 class="wp-block-heading">News</h1>
+  <!-- /wp:heading -->
+</div>
 <!-- /wp:group -->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
 <div class="wp-block-group"><!-- wp:columns -->
-<div class="wp-block-columns"><!-- wp:column {"width":"25%"} -->
-<div class="wp-block-column" style="flex-basis:25%"><!-- wp:categories /--></div>
-<!-- /wp:column -->
+  <div class="wp-block-columns"><!-- wp:column {"width":"25%"} -->
+    <div class="wp-block-column" style="flex-basis:25%"><!-- wp:categories /--></div>
+    <!-- /wp:column -->
 
-<!-- wp:column {"width":"75%"} -->
-<div class="wp-block-column" style="flex-basis:75%"><!-- wp:query {"queryId":0,"query":{"perPage":"12","pages":"10","offset":0,"postType":"post","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]},"displayLayout":{"type":"flex","columns":3}} -->
-<div class="wp-block-query"><!-- wp:post-template -->
-<!-- wp:columns -->
-<div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
-<div class="wp-block-column" style="flex-basis:100%"><!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+    <!-- wp:column {"width":"75%"} -->
+    <div class="wp-block-column" style="flex-basis:75%">
+      <!-- wp:query {"queryId":0,"query":{"perPage":"12","pages":"10","offset":0,"postType":"post","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]},"displayLayout":{"type":"flex","columns":3}} -->
+      <div class="wp-block-query"><!-- wp:post-template -->
+        <!-- wp:columns -->
+        <div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
+          <div class="wp-block-column" style="flex-basis:100%">
+            <!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
 
-<!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|navy"}}}}} /-->
+            <!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|navy"}}}}} /-->
 
-<!-- wp:post-title {"isLink":true} /-->
+            <!-- wp:post-title {"isLink":true} /-->
 
-<!-- wp:post-excerpt {"moreText":"Read More"} /--></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->
-<!-- /wp:post-template -->
+            <!-- wp:post-excerpt {"moreText":"Read More"} /-->
+          </div>
+          <!-- /wp:column -->
+        </div>
+        <!-- /wp:columns -->
+        <!-- /wp:post-template -->
 
-<!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
-<!-- wp:query-pagination-previous {"label":" "} /-->
+        <!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
+        <!-- wp:query-pagination-previous {"label":" "} /-->
 
-<!-- wp:query-pagination-numbers /-->
+        <!-- wp:query-pagination-numbers /-->
 
-<!-- wp:query-pagination-next {"label":" "} /-->
-<!-- /wp:query-pagination -->
+        <!-- wp:query-pagination-next {"label":" "} /-->
+        <!-- /wp:query-pagination -->
 
-<!-- wp:query-no-results -->
-<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-<p></p>
-<!-- /wp:paragraph -->
-<!-- /wp:query-no-results --></div>
-<!-- /wp:query --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
+        <!-- wp:query-no-results -->
+        <!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+        <p></p>
+        <!-- /wp:paragraph -->
+        <!-- /wp:query-no-results -->
+      </div>
+      <!-- /wp:query -->
+    </div>
+    <!-- /wp:column -->
+  </div>
+  <!-- /wp:columns -->
+</div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group"><!-- wp:post-content {"layout":{"type":"constrained"}} /--></main>

--- a/templates/page.html
+++ b/templates/page.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:group {"tagName":"main"} -->
 <main class="wp-block-group"><!-- wp:post-content {"layout":{"type":"constrained"}} /--></main>

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,39 +1,45 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40","padding":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
-<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:query-title {"type":"search"} /-->
+<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)">
+  <!-- wp:query-title {"type":"search"} /-->
 
-<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search"} /-->
+  <!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search"} /-->
 
-<!-- wp:query {"queryId":0,"query":{"perPage":"12","pages":"10","offset":0,"postType":"post","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]},"displayLayout":{"type":"flex","columns":3}} -->
-<div class="wp-block-query"><!-- wp:post-template -->
-<!-- wp:columns -->
-<div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
-<div class="wp-block-column" style="flex-basis:100%"><!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+  <!-- wp:query {"queryId":0,"query":{"perPage":"12","pages":"10","offset":0,"postType":"post","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]},"displayLayout":{"type":"flex","columns":3}} -->
+  <div class="wp-block-query"><!-- wp:post-template -->
+    <!-- wp:columns -->
+    <div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
+      <div class="wp-block-column" style="flex-basis:100%">
+        <!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
 
-<!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|navy"}}}}} /-->
+        <!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|navy"}}}}} /-->
 
-<!-- wp:post-title {"isLink":true} /-->
+        <!-- wp:post-title {"isLink":true} /-->
 
-<!-- wp:post-excerpt {"moreText":"Read More"} /--></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->
-<!-- /wp:post-template -->
+        <!-- wp:post-excerpt {"moreText":"Read More"} /-->
+      </div>
+      <!-- /wp:column -->
+    </div>
+    <!-- /wp:columns -->
+    <!-- /wp:post-template -->
 
-<!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
-<!-- wp:query-pagination-previous {"label":" "} /-->
+    <!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
+    <!-- wp:query-pagination-previous {"label":" "} /-->
 
-<!-- wp:query-pagination-numbers /-->
+    <!-- wp:query-pagination-numbers /-->
 
-<!-- wp:query-pagination-next {"label":" "} /-->
-<!-- /wp:query-pagination -->
+    <!-- wp:query-pagination-next {"label":" "} /-->
+    <!-- /wp:query-pagination -->
 
-<!-- wp:query-no-results -->
-<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-<p></p>
-<!-- /wp:paragraph -->
-<!-- /wp:query-no-results --></div>
-<!-- /wp:query --></div>
+    <!-- wp:query-no-results -->
+    <!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+    <p></p>
+    <!-- /wp:paragraph -->
+    <!-- /wp:query-no-results -->
+  </div>
+  <!-- /wp:query -->
+</div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,45 +1,39 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40","padding":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
-<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)">
-  <!-- wp:query-title {"type":"search"} /-->
+<div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:query-title {"type":"search"} /-->
 
-  <!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search"} /-->
+<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search"} /-->
 
-  <!-- wp:query {"queryId":0,"query":{"perPage":"12","pages":"10","offset":0,"postType":"post","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]},"displayLayout":{"type":"flex","columns":3}} -->
-  <div class="wp-block-query"><!-- wp:post-template -->
-    <!-- wp:columns -->
-    <div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
-      <div class="wp-block-column" style="flex-basis:100%">
-        <!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
+<!-- wp:query {"queryId":0,"query":{"perPage":"12","pages":"10","offset":0,"postType":"post","order":"asc","orderBy":"title","author":"","search":"","exclude":[],"sticky":"","inherit":false,"parents":[]},"displayLayout":{"type":"flex","columns":3}} -->
+<div class="wp-block-query"><!-- wp:post-template -->
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"100%"} -->
+<div class="wp-block-column" style="flex-basis:100%"><!-- wp:post-featured-image {"isLink":true,"style":{"spacing":{"margin":{"bottom":"0"}}}} /-->
 
-        <!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|navy"}}}}} /-->
+<!-- wp:post-terms {"term":"category","style":{"elements":{"link":{"color":{"text":"var:preset|color|navy"}}}}} /-->
 
-        <!-- wp:post-title {"isLink":true} /-->
+<!-- wp:post-title {"isLink":true} /-->
 
-        <!-- wp:post-excerpt {"moreText":"Read More"} /-->
-      </div>
-      <!-- /wp:column -->
-    </div>
-    <!-- /wp:columns -->
-    <!-- /wp:post-template -->
+<!-- wp:post-excerpt {"moreText":"Read More"} /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+<!-- /wp:post-template -->
 
-    <!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
-    <!-- wp:query-pagination-previous {"label":" "} /-->
+<!-- wp:query-pagination {"paginationArrow":"chevron","layout":{"type":"flex","justifyContent":"center"}} -->
+<!-- wp:query-pagination-previous {"label":" "} /-->
 
-    <!-- wp:query-pagination-numbers /-->
+<!-- wp:query-pagination-numbers /-->
 
-    <!-- wp:query-pagination-next {"label":" "} /-->
-    <!-- /wp:query-pagination -->
+<!-- wp:query-pagination-next {"label":" "} /-->
+<!-- /wp:query-pagination -->
 
-    <!-- wp:query-no-results -->
-    <!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-    <p></p>
-    <!-- /wp:paragraph -->
-    <!-- /wp:query-no-results -->
-  </div>
-  <!-- /wp:query -->
-</div>
+<!-- wp:query-no-results -->
+<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
+<p></p>
+<!-- /wp:paragraph -->
+<!-- /wp:query-no-results --></div>
+<!-- /wp:query --></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|40","padding":{"bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
 <div class="wp-block-group" style="padding-bottom:var(--wp--preset--spacing--50)"><!-- wp:query-title {"type":"search"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,45 +1,59 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:cover {"overlayColor":"blue","contentPosition":"center center"} -->
-<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-blue-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignwide"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
-<div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:post-title {"textAlign":"left","level":1} /-->
+<div class="wp-block-cover"><span aria-hidden="true"
+    class="wp-block-cover__background has-blue-background-color has-background-dim-100 has-background-dim"></span>
+  <div class="wp-block-cover__inner-container"><!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+    <div class="wp-block-group alignwide"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
+      <div class="wp-block-columns alignwide are-vertically-aligned-center">
+        <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
+          <!-- wp:post-title {"textAlign":"left","level":1} /-->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"6px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:paragraph -->
-<p>Published on</p>
-<!-- /wp:paragraph -->
+          <!-- wp:group {"style":{"spacing":{"blockGap":"6px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+          <div class="wp-block-group"><!-- wp:paragraph -->
+            <p>Published on</p>
+            <!-- /wp:paragraph -->
 
-<!-- wp:post-date /--></div>
-<!-- /wp:group -->
+            <!-- wp:post-date /-->
+          </div>
+          <!-- /wp:group -->
 
-<!-- wp:group {"style":{"spacing":{"blockGap":"6px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:paragraph -->
-<p>By</p>
-<!-- /wp:paragraph -->
+          <!-- wp:group {"style":{"spacing":{"blockGap":"6px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+          <div class="wp-block-group"><!-- wp:paragraph -->
+            <p>By</p>
+            <!-- /wp:paragraph -->
 
-<!-- wp:post-author {"showAvatar":false,"showBio":false} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:column -->
+            <!-- wp:post-author {"showAvatar":false,"showBio":false} /-->
+          </div>
+          <!-- /wp:group -->
+        </div>
+        <!-- /wp:column -->
 
-<!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:post-featured-image {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} /--></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns --></div>
-<!-- /wp:group -->
+        <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
+        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
+          <!-- wp:post-featured-image {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} /-->
+        </div>
+        <!-- /wp:column -->
+      </div>
+      <!-- /wp:columns -->
+    </div>
+    <!-- /wp:group -->
 
-<!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"></div>
-<!-- /wp:group --></div></div>
+    <!-- wp:group {"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group"></div>
+    <!-- /wp:group -->
+  </div>
+</div>
 <!-- /wp:cover -->
 
 <!-- wp:group {"layout":{"type":"constrained","contentSize":"800px"}} -->
 <div class="wp-block-group"><!-- wp:post-content {"style":{"typography":{"lineHeight":1.4}},"fontSize":"small"} /-->
 
-<!-- wp:spacer {"height":"40px"} -->
-<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
-<!-- /wp:spacer --></div>
+  <!-- wp:spacer {"height":"40px"} -->
+  <div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+  <!-- /wp:spacer -->
+</div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,4 +1,4 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
 
 <!-- wp:cover {"overlayColor":"blue","contentPosition":"center center"} -->
 <div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-blue-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->

--- a/templates/single.html
+++ b/templates/single.html
@@ -1,59 +1,45 @@
-<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header mt-0"} /-->
+<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header is-style-kindling-sticky-header mt-0"} /-->
 
 <!-- wp:cover {"overlayColor":"blue","contentPosition":"center center"} -->
-<div class="wp-block-cover"><span aria-hidden="true"
-    class="wp-block-cover__background has-blue-background-color has-background-dim-100 has-background-dim"></span>
-  <div class="wp-block-cover__inner-container"><!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
-    <div class="wp-block-group alignwide"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
-      <div class="wp-block-columns alignwide are-vertically-aligned-center">
-        <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
-          <!-- wp:post-title {"textAlign":"left","level":1} /-->
+<div class="wp-block-cover"><span aria-hidden="true" class="wp-block-cover__background has-blue-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"align":"wide","layout":{"type":"constrained"}} -->
+<div class="wp-block-group alignwide"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
+<div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:post-title {"textAlign":"left","level":1} /-->
 
-          <!-- wp:group {"style":{"spacing":{"blockGap":"6px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-          <div class="wp-block-group"><!-- wp:paragraph -->
-            <p>Published on</p>
-            <!-- /wp:paragraph -->
+<!-- wp:group {"style":{"spacing":{"blockGap":"6px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>Published on</p>
+<!-- /wp:paragraph -->
 
-            <!-- wp:post-date /-->
-          </div>
-          <!-- /wp:group -->
+<!-- wp:post-date /--></div>
+<!-- /wp:group -->
 
-          <!-- wp:group {"style":{"spacing":{"blockGap":"6px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-          <div class="wp-block-group"><!-- wp:paragraph -->
-            <p>By</p>
-            <!-- /wp:paragraph -->
+<!-- wp:group {"style":{"spacing":{"blockGap":"6px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+<div class="wp-block-group"><!-- wp:paragraph -->
+<p>By</p>
+<!-- /wp:paragraph -->
 
-            <!-- wp:post-author {"showAvatar":false,"showBio":false} /-->
-          </div>
-          <!-- /wp:group -->
-        </div>
-        <!-- /wp:column -->
+<!-- wp:post-author {"showAvatar":false,"showBio":false} /--></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
 
-        <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-        <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
-          <!-- wp:post-featured-image {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} /-->
-        </div>
-        <!-- /wp:column -->
-      </div>
-      <!-- /wp:columns -->
-    </div>
-    <!-- /wp:group -->
+<!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:post-featured-image {"style":{"spacing":{"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}}} /--></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
 
-    <!-- wp:group {"layout":{"type":"constrained"}} -->
-    <div class="wp-block-group"></div>
-    <!-- /wp:group -->
-  </div>
-</div>
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<div class="wp-block-group"></div>
+<!-- /wp:group --></div></div>
 <!-- /wp:cover -->
 
 <!-- wp:group {"layout":{"type":"constrained","contentSize":"800px"}} -->
 <div class="wp-block-group"><!-- wp:post-content {"style":{"typography":{"lineHeight":1.4}},"fontSize":"small"} /-->
 
-  <!-- wp:spacer {"height":"40px"} -->
-  <div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
-  <!-- /wp:spacer -->
-</div>
+<!-- wp:spacer {"height":"40px"} -->
+<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer --></div>
 <!-- /wp:group -->
 
 <!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer"} /-->


### PR DESCRIPTION
## Changes proposed in this pull request

This is a clean-up task to remove an unused header class.

This PR removes the class `.is-style-kindling-sticky-header` from the header in template files.

Note: There are two instances where the diff shows a change where in templates where the footer is being called. VS Code auto-removed the last empty line. No other changes.

Closes https://app.asana.com/0/1203895219649773/1206518703604971/f

┆Issue is synchronized with this [Asana task](https://app.asana.com/0/1203895219649773/1206803623257474)
