### PR TITLE
Fix overrides.scss

### DIFF
--- a/assets/styles/base/overrides.scss
+++ b/assets/styles/base/overrides.scss
@@ -1,11 +1,15 @@
 .editor-styles-wrapper,
 .wp-site-blocks {
 
+
+  // Set margin-block-start to 0 for <footer> and <main> elements.
+  header,
   footer,
   main {
     margin-block-start: 0;
   }
 
+  // Set margin-block-start to 0 child elements of is-layout-constrained and is-layout-flow where the child element has a background.
   .is-layout-constrained,
   .is-layout-flow {
     :where(.has-background) {

--- a/assets/styles/base/overrides.scss
+++ b/assets/styles/base/overrides.scss
@@ -1,31 +1,28 @@
-body {
+.editor-styles-wrapper,
+.wp-site-blocks {
 
-  .editor-styles-wrapper,
-  .wp-site-blocks {
-
-    footer,
-    main {
-      margin-block-start: 0;
-    }
-
-    .is-layout-constrained,
-    .is-layout-flow {
-      :where(.has-background) {
-        margin-block-start: 0;
-      }
-    }
+  footer,
+  main {
+    margin-block-start: 0;
   }
 
-  // Fixes an issue with WP 6.4.3 and heading text color.
-  .editor-styles-wrapper {
-
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-      color: inherit;
+  .is-layout-constrained,
+  .is-layout-flow {
+    :where(.has-background) {
+      margin-block-start: 0;
     }
+  }
+}
+
+// Fixes an issue with WP 6.4.3 and heading text color.
+.editor-styles-wrapper {
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    color: inherit;
   }
 }

--- a/theme.json
+++ b/theme.json
@@ -659,7 +659,7 @@
       "background": "var(--wp--preset--color--white)",
       "text": "var(--wp--preset--color--dark-grey)"
     },
-    "css": ".wp-site-blocks > * + * {\n    margin-block-start: 0;\n}\n\n.wp-block-navigation-item__content {\n    font-weight: bold;\n}\n\n.shadow-xs {\n    box-shadow: 0px 2px 4px -2px rgba(16, 24, 40, 0.1), 0px 4px 6px -1px rgba(16, 24, 40, 0.1);\n}\n\n.shadow-sm {\n    box-shadow: 0px 4px 12px rgba(0, 0, 0, 0.16);\n}\n\n.shadow-md {\n    box-shadow: 0px 25px 50px -12px rgba(16, 24, 40, 0.1);\n}\n\n.card-latest-news {\n    border: 1px solid #EDEDED;\n    box-shadow: 0px 100px 80px rgba(0, 0, 0, 0.02), 0px 64.8148px 46.8519px rgba(0, 0, 0, 0.0151852), 0px 38.5185px 25.4815px rgba(0, 0, 0, 0.0121481), 0px 20px 13px rgba(0, 0, 0, 0.01), 0px 8.14815px 6.51852px rgba(0, 0, 0, 0.00785185), 0px 1.85185px 3.14815px rgba(0, 0, 0, 0.00481481);\n}\n",
+    "css": "",
     "elements": {
       "button": {
         "color": {


### PR DESCRIPTION
## Changes proposed in this pull request

This PR fixes the selectors in the overrides.scss file to properly load the styles. The styles were wrapped with <body> and that needed to be removed. 

Also the theme.json had "Additional CSS" in it carried over from an earlier site build. All styles could be removed except the first one was a reset for top margins. However, it did the same thing as selecting header, footer, and main. Those have been added to the overrides instead. The theme.json now has now no Additional CSS by default.

This PR effects the following two tasks:

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207037269973152
  - https://app.asana.com/0/0/1207037268961404