### PR TITLE
Add responsive columns

### DIFF
--- a/assets/scripts/front.js
+++ b/assets/scripts/front.js
@@ -38,6 +38,20 @@ document.addEventListener('DOMContentLoaded', function () {
     });
   });
 
+  // Column classes
+  function columnClasses() {
+    const columnBlocks = document.querySelectorAll('.wp-block-columns');
+
+    columnBlocks.forEach((block) => {
+      const columns = block.querySelectorAll('.wp-block-column');
+      const columnCount = columns.length;
+
+      // Add new class based on column count
+      block.classList.add(`has-${columnCount}-columns`);
+    });
+  }
+  columnClasses();
+
   /**
   * A11y
   */

--- a/assets/styles/base/layout.scss
+++ b/assets/styles/base/layout.scss
@@ -1,0 +1,60 @@
+// Root padding aware alignment fix
+
+/// When a top-level block is set to "align full" and "inner content is content width"
+/// the inner content will get the left/right root padding applied automatically.
+///
+/// This can be overridden in the editor by adding padding to the inner content block
+/// if it is set to zero it will not have padding, hitting reset will remove that and
+/// then the theme padding will be added with this css.
+
+.wp-block-post-content.has-global-padding {
+  >.alignfull {
+    padding-left: var(--wp--style--root--padding-left);
+    padding-right: var(--wp--style--root--padding-right);
+  }
+}
+
+// Columns
+
+// Query Block columns
+.wp-block-query {
+  .wp-block-post-template.is-layout-grid {
+    &.columns-2 {
+
+      @screen md {
+        grid-template-columns: minmax(0, 1fr);
+      }
+    }
+
+    &.columns-4,
+    &.columns-5,
+    &.columns-6 {
+      @apply -md:grid-cols-3
+    }
+
+    &.columns-4,
+    &.columns-5,
+    &.columns-6 {
+      @apply -sm:grid-cols-2;
+    }
+
+  }
+}
+
+// Columns
+.wp-block-columns {
+  &.is-layout-flex {
+
+    // 4 Columns goes to 2 columns at tablet
+    &.has-4-columns {
+      @apply -md:flex -md:flex-wrap gap-5;
+
+      &:not(.is-not-stacked-on-mobile)>.wp-block-column {
+        @screen -md {
+          flex-basis: calc(50% - 10px) !important;
+          flex-grow: 1;
+        }
+      }
+    }
+  }
+}

--- a/assets/styles/editor.scss
+++ b/assets/styles/editor.scss
@@ -4,6 +4,7 @@
 
 @import './base/global';
 @import './base/overrides';
+@import './base/layout';
 
 @import './utilities/icons';
 @import './utilities/utilities';

--- a/assets/styles/front.scss
+++ b/assets/styles/front.scss
@@ -4,6 +4,7 @@
 
 @import './base/global';
 @import './base/overrides';
+@import './base/layout';
 
 @import './utilities/icons';
 @import './utilities/utilities';


### PR DESCRIPTION
This PR adds an earlier feature used on several projects. However, it was never added to repo.

The core behavior of Columns has them going to 100% at tablet view. This is a jarring UX and takes up unnecessary amounts of screen space. 

A script adds a class to identify the number of columns and styles make adjustments. 

Also missing is a Root padding fix.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205764853609958