### PR TITLE
Enable font weight

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -339,8 +339,7 @@
           "size": "5rem",
           "slug": "heading"
         }
-      ],
-      "fontWeight": false
+      ]
     },
     "useRootPaddingAwareAlignments": true
   },


### PR DESCRIPTION
This PR enables Font Weight in the block editor as Typography > Appearance.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206707620180377