### PR TITLE
Base editor-js dependencies

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -91,10 +91,11 @@ add_action('wp_enqueue_scripts', 'kindling_scripts');
  */
 function kindling_editor_assets()
 {
+  // There are additional dependencies that can be added. For example `wp-data` but we want to keep this as lean as possible in the base theme. You may add more if needed in your project.
   wp_enqueue_script(
     'editor-js',
     get_theme_file_uri('build/editor.js'),
-    ['wp-blocks', 'wp-i18n', 'wp-element', 'wp-components', 'wp-editor', 'wp-dom-ready', 'wp-edit-post'],
+    ['wp-blocks', 'wp-i18n', 'wp-element', 'wp-components', 'wp-editor', 'wp-dom-ready', 'wp-edit-post', 'wp-block-editor'],
     filemtime(get_template_directory() . '/build/editor.js')
   );
   wp_enqueue_style(


### PR DESCRIPTION
This PR adds `wp-block-editor` to the base dependencies for `editor-js`.

The dependencies we load cover most of the commonly used WordPress packages required for block development in the editor context. However, whether you need to include additional dependencies depends on the specific functionality and imports used within your editor.js file.

The imports in individual block files are also needed and serve a separate purpose:
- `wp_enqueue_script()` handles the loading of scripts and dependencies in the WordPress environment.
- ES6+ imports are for coding and bundling your scripts using modern JavaScript practices.