### PR TITLE
Add playground blueprint for a11y testing

### DIFF
--- a/.playground/blueprint-a11y-test.json
+++ b/.playground/blueprint-a11y-test.json
@@ -1,0 +1,44 @@
+{
+	"$schema": "https://playground.wordpress.net/blueprint-schema.json",
+	"login": true,
+	"features": {
+		"networking": true
+	},
+	"preferredVersions": {
+		"php": "8.0",
+		"wp": "latest"
+	},
+	"steps": [
+		{
+			"step": "updateUserMeta",
+			"meta": {
+				"admin_color": "modern",
+				"show_welcome_panel": 0
+			},
+			"userId": 1
+		},
+		{
+			"step": "setSiteOptions",
+			"options": {
+				"blogname": "Kindling Demo"
+			}
+		},
+		{
+			"step": "installTheme",
+			"themeData": {
+				"resource": "url",
+				"url": "https://github-proxy.com/proxy/?repo=matchboxdesigngroup/kindling&branch=4.0.0-alpha"
+			},
+			"options": {
+				"activate": true
+			}
+		},
+		{
+			"step": "importWxr",
+			"file": {
+				"resource": "url",
+				"url": "https://github.com/wpaccessibility/a11y-theme-unit-test/blob/master/a11y-theme-unit-test-data.xml"
+			}
+		}
+	]
+}


### PR DESCRIPTION
## Changes proposed in this pull request

This PR adds a blueprint for testing the theme in a WordPress Playground.

Once the blueprint is in place, we will introduce future functionality that references this file.

## Testing

### How to test the changes in this pull request

Follow the steps below to test the changes in this PR.

1. Navigate to https://playground.wordpress.net/builder/.
2. Copy and paste the contents of the `blueprint-a11y-test.json` file into the editor window.
3. Press the "Run It" button.

### Functional tests

As the functional tester for this pull request, I verify that:

- [ ] It logs you in as an admin.
- [ ] It installs the theme.
- [ ] It installs the a11y testing data.
