### PR TITLE
Disable custom layout width in global styles

### DIFF
--- a/docs/global-settings-and-styles.md
+++ b/docs/global-settings-and-styles.md
@@ -1,0 +1,10 @@
+# Global styles and settings
+
+Kindling uses the `theme.json` to configure global settings, styles and template parts. We also use named `.json` files in the styles directory to define custom style variations. 
+
+- Settings: The standard and custom settings we configure via `theme.json`.
+- Styles: The standard design system for styling elements and blocks via `theme.json`.
+- Custom Templates: Register custom post, page, and CPT templates.
+- Template Parts: Register custom template parts that are reused across the theme.
+- Patterns: Kindling does not use the Patterns property.
+- Style Variations: Custom style variations providing alternate designs from the `theme.json`.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,38 @@
+# Settings
+
+`settings` is a top-level property in `theme.json` and has multiple nested properties.
+
+```
+{
+	"version": 3,
+	"settings": {
+		"appearanceTools": true,
+		"border": {},
+		"color": {},
+		"custom": {},
+		"dimensions": {},
+		"layout": {},
+		"position": {},
+		"shadow": {},
+		"spacing": {},
+		"typography": {},
+		"useRootPaddingAwareAlignments": true,
+		"blocks": {}
+	}
+}
+```
+
+## Layout settings
+
+The `settings.layout` property is an object that stores settings to control the default widths for "content" and "wide" sizes.
+
+The properties we define are:
+
+- `allowCustomContentAndWideSize`: A boolean to show/hide the inputs for the content and wide widths in the layout settings of the Group block.
+- `contentSize`: A valid CSS length value for defining the default width for prose style content.
+- `wideSize`: A valid CSS length value for defining the default wide alignment width. Think of this as the container width from the Bootstrap days.
+
+### Resources
+
+- [Layout](https://developer.wordpress.org/themes/global-settings-and-styles/settings/layout/) (WordPress Theme Handbook)
+- [Theme.json layout and spacing options](https://fullsiteediting.com/lessons/theme-json-layout-and-spacing-options/) (Full Site Editing)

--- a/theme.json
+++ b/theme.json
@@ -3,6 +3,7 @@
 	"settings": {
 		"appearanceTools": true,
 		"layout": {
+			"allowCustomContentAndWideSize": false,
 			"contentSize": "620px",
 			"wideSize": "1000px"
 		},


### PR DESCRIPTION
## Changes proposed in this pull request

This PR adds the `settings.layout.allowCustomContentAndWideSize` property to the `theme.json` file to disable the editor's custom content and wide size inputs. This will maintain design system consistency and simplify the content editing experience. 

It will also ensure that all content follows predefined width constraints, reducing layout inconsistencies and improving the overall user experience.

| Before | After |
|--------|-------|
|<img width="293" alt="Screenshot 2025-03-11 at 8 18 11 PM" src="https://github.com/user-attachments/assets/ec3b11dd-4aeb-43ef-a9dd-98c5e49341ec" />|<img width="296" alt="Screenshot 2025-03-11 at 8 17 30 PM" src="https://github.com/user-attachments/assets/cf9b7981-7cda-4cdb-90ac-6ee122e35832" />|

## Testing

### How to test the changes in this pull request

Follow the steps below to test the changes in this PR.

1. Open this branch in a local environment.
2. Navigate to a page in the admin.
3. Add a group block.

### Functional tests

As the functional tester for this pull request, I verify that:

- [ ] It does not have the content width or wide width inputs in the Layout panel.
