### PR TITLE
theme.json: Add spacing presets

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -3,8 +3,8 @@
 	"settings": {
 		"appearanceTools": true,
 		"layout": {
-			"contentSize": "620px",
-			"wideSize": "1000px"
+			"contentSize": "1200px",
+			"wideSize": "1400px"
 		},
 		"spacing": {
 			"units": [
@@ -26,6 +26,18 @@
 			]
 		},
 		"useRootPaddingAwareAlignments": true
+	},
+	"styles": {
+		"typography": {
+			"fontFamily": "var(--wp--preset--font-family--system-font)"
+		},
+		"blocks": {
+			"core/button": {
+				"border": {
+					"radius": "0px"
+				}
+			}
+		  }
 	},
 	"templateParts": [
 		{

--- a/theme.json
+++ b/theme.json
@@ -28,6 +28,15 @@
 		"useRootPaddingAwareAlignments": true
 	},
 	"styles": {
+		"spacing": {
+			"blockGap": "1.5rem",
+			"padding": {
+				"bottom": "0",
+				"left": "var(--wp--preset--spacing--30)",
+				"right": "var(--wp--preset--spacing--30)",
+				"top": "0"
+			}
+		},
 		"typography": {
 			"fontFamily": "var(--wp--preset--font-family--system-font)"
 		},

--- a/theme.json
+++ b/theme.json
@@ -4,7 +4,7 @@
 		"appearanceTools": true,
 		"layout": {
 			"contentSize": "1200px",
-			"wideSize": "1400px"
+			"wideSize": "1440px"
 		},
 		"spacing": {
 			"units": [

--- a/theme.json
+++ b/theme.json
@@ -37,7 +37,7 @@
 					"radius": "0px"
 				}
 			}
-		  }
+		}
 	},
 	"templateParts": [
 		{

--- a/theme.json
+++ b/theme.json
@@ -36,7 +36,7 @@
 				},
 				{
 					"name": "6 / 120px",
-					"size": "clamp(2.5rem, 2.75rem + ((1vw - 0.48rem) * 9.096), 7.5rem)",
+					"size": "clamp(2.75rem, 2.75rem + ((1vw - 0.48rem) * 9.096), 7.5rem)",
 					"slug": "60"
 				},
 				{

--- a/theme.json
+++ b/theme.json
@@ -7,6 +7,44 @@
 			"wideSize": "1440px"
 		},
 		"spacing": {
+			"defaultSpacingSizes": false,
+			"spacingSizes": [
+				{
+					"name": "1 / 24px",
+					"size": "1.5rem",
+					"slug": "10"
+				},
+				{
+					"name": "2 / 32px",
+					"size": "clamp(1.5rem, 5vw, 2rem)",
+					"slug": "20"
+				},
+				{
+					"name": "3 / 40px",
+					"size": "clamp(1.875rem, 1.875rem + ((1vw - 0.48rem) * 2.885), 2.5rem)",
+					"slug": "30"
+				},
+				{
+					"name": "4 / 56px",
+					"size": "clamp(2rem, 2rem + ((1vw - 0.48rem) * 2.885), 3.5rem)",
+					"slug": "40"
+				},
+				{
+					"name": "5 / 72px",
+					"size": "clamp(2.5rem, 2rem + ((1vw - 0.48rem) * 5), 4.5rem)",
+					"slug": "50"
+				},
+				{
+					"name": "6 / 120px",
+					"size": "clamp(2.5rem, 2.75rem + ((1vw - 0.48rem) * 9.096), 7.5rem)",
+					"slug": "60"
+				},
+				{
+					"name": "7 / 160px",
+					"size": "clamp(3.5rem, 14vw, 10rem)",
+					"slug": "70"
+				}
+			],
 			"units": [
 				"%",
 				"px",


### PR DESCRIPTION
## Changes proposed in this pull request

This PR adds proposed spacing presets with scaling and disables the defaults.

These are sizes that were used on several recent projects and should match the spacing defaults we're using in Figma.
**Figma variables**
![Screenshot 2025-05-12 at 3 17 26 PM](https://github.com/user-attachments/assets/ff18cc26-ed55-492e-b06f-968b87f905ba)

The Min Size is the smallest on the scale (mobile).

| Slug | Max Size | Min Size |
|--------|--------|--------|
| 10 | 24px | n/a |
| 20 | 32px | 24px |
| 30 | 40px | 30px |
| 40 | 56px | 32px |
| 50 | 72px | 40px |
| 60 | 120px | 44px |
| 70 | 160px | 56px |


