### PR TITLE
Rename Matchbox Grid to Kindling Grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ A block theme for WordPress that supports the Full Site Editing features.
 
 ### Added
 - Draft documentation for the `theme.json` token system at [Kindling Docs](https://kindling.matchbox.host/getting-started/kindling-theme-json/).
-- Introduced Matchbox Grid System styles to Kindling for consistent layout support.
+- Introduced Kindling Grid System styles to Kindling for consistent layout support.
 
 ### Changed
 - Updated `theme.json` to bring it closer to a production-ready starter.

--- a/assets/blocks/kindling-grid-system.css
+++ b/assets/blocks/kindling-grid-system.css
@@ -1,5 +1,5 @@
 @media (max-width: 767px) {
-	.is-style-matchbox-grid-system {
+	.is-style-kindling-grid-system {
 		grid-template-columns: repeat(6, 1fr) !important;
 		gap: var(--wp--preset--spacing--20);
 	}

--- a/functions.php
+++ b/functions.php
@@ -132,7 +132,7 @@ function register_theme_patterns() {
 
 		// If "Categories: cat1, cat2", convert to array.
 		if ( ! empty( $header['categories'] ) ) {
-			// E.g. "matchbox/media, matchbox/featured, matchbox/gallery"
+			// E.g. "kindling/media, kindling/featured, kindling/gallery"
 			$cats = array_map( 'trim', explode( ',', $header['categories'] ) );
 			$pattern_args['categories'] = $cats;
 		}
@@ -154,7 +154,7 @@ function register_theme_patterns() {
 			$pattern_args['inserter'] = ( 'true' === strtolower( $header['inserter'] ) );
 		}
 
-		// 'Slug' should follow the format 'namespace/pattern-slug' like 'matchbox/instagram-grid'.
+		// 'Slug' should follow the format 'namespace/pattern-slug' like 'kindling/instagram-grid'.
 		$name = $pattern_args['slug'] ? sanitize_title( $pattern_args['slug'] ) : null;
 
 		// Bail if we don't have a name or title.
@@ -200,11 +200,11 @@ add_action( 'init', __NAMESPACE__ . '\register_theme_patterns' );
  */
 function enqueue_block_styles() {
 	wp_enqueue_block_style(
-		'matchbox/grid-item',
+		'kindling/grid-item',
 		[
-			'handle' => 'kindling-block-matchbox-grid-item',
-			'src'    => get_theme_file_uri( 'assets/blocks/matchbox-grid-system.css' ),
-			'path'   => get_theme_file_path( 'assets/blocks/matchbox-grid-system.css' ),
+			'handle' => 'kindling-block-grid-item',
+			'src'    => get_theme_file_uri( 'assets/blocks/kindling-grid-system.css' ),
+			'path'   => get_theme_file_path( 'assets/blocks/kindling-grid-system.css' ),
 		]
 	);
 }

--- a/styles/blocks/grid-item-span-full-to-half.json
+++ b/styles/blocks/grid-item-span-full-to-half.json
@@ -2,7 +2,7 @@
 	"title": "Full to 1/2",
 	"slug": "grid-item-span-full-to-half",
 	"blockTypes": [
-		"matchbox/grid-item"
+		"kindling/grid-item"
 	],
 	"styles": {
 		"css": "grid-column: span 6;"

--- a/styles/blocks/grid-item-span-full-to-one-quarter.json
+++ b/styles/blocks/grid-item-span-full-to-one-quarter.json
@@ -2,7 +2,7 @@
 	"title": "Full to 1/4",
 	"slug": "grid-item-span-full-to-one-quarter",
 	"blockTypes": [
-		"matchbox/grid-item"
+		"kindling/grid-item"
 	],
 	"styles": {
 		"css": "grid-column: span 3;"

--- a/styles/blocks/grid-item-span-full-to-one-third.json
+++ b/styles/blocks/grid-item-span-full-to-one-third.json
@@ -2,7 +2,7 @@
 	"title": "Full to 1/3",
 	"slug": "grid-item-span-full-to-one-third",
 	"blockTypes": [
-		"matchbox/grid-item"
+		"kindling/grid-item"
 	],
 	"styles": {
 		"css": "grid-column: span 4;"

--- a/styles/blocks/grid-item-span-full-to-three-quarters.json
+++ b/styles/blocks/grid-item-span-full-to-three-quarters.json
@@ -2,7 +2,7 @@
 	"title": "Full to 3/4",
 	"slug": "grid-item-span-full-to-three-quarters",
 	"blockTypes": [
-		"matchbox/grid-item"
+		"kindling/grid-item"
 	],
 	"styles": {
 		"css": "grid-column: span 9;"

--- a/styles/blocks/grid-item-span-full-to-two-thirds.json
+++ b/styles/blocks/grid-item-span-full-to-two-thirds.json
@@ -2,7 +2,7 @@
 	"title": "Full to 2/3",
 	"slug": "grid-item-span-full-to-two-thirds",
 	"blockTypes": [
-		"matchbox/grid-item"
+		"kindling/grid-item"
 	],
 	"styles": {
 		"css": "grid-column: span 8;"

--- a/styles/blocks/grid-item-span-half.json
+++ b/styles/blocks/grid-item-span-half.json
@@ -2,7 +2,7 @@
 	"title": "1/2",
 	"slug": "grid-item-span-half",
 	"blockTypes": [
-		"matchbox/grid-item"
+		"kindling/grid-item"
 	],
 	"styles": {
 		"css": "grid-column: span 6;"

--- a/styles/blocks/grid-item-span-one-third.json
+++ b/styles/blocks/grid-item-span-one-third.json
@@ -2,7 +2,7 @@
 	"title": "1/3",
 	"slug": "grid-item-span-one-third",
 	"blockTypes": [
-		"matchbox/grid-item"
+		"kindling/grid-item"
 	],
 	"styles": {
 		"css": "grid-column: span 4;"

--- a/styles/blocks/grid-item-span-two-thirds.json
+++ b/styles/blocks/grid-item-span-two-thirds.json
@@ -2,7 +2,7 @@
 	"title": "2/3",
 	"slug": "grid-item-span-two-thirds",
 	"blockTypes": [
-		"matchbox/grid-item"
+		"kindling/grid-item"
 	],
 	"styles": {
 		"css": "grid-column: span 8;"


### PR DESCRIPTION
This PR rename Matchbox Grid to Kindling Grid to match the new name we have on the Kindling Blocks plugin.
Related to: https://github.com/matchboxdesigngroup/matchbox-blocks/pull/82