### PR TITLE
Persistent admin notice to install or activate Kindling Blocks when the theme is activated.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -209,3 +209,5 @@ function enqueue_block_styles() {
 	);
 }
 add_action( 'init', __NAMESPACE__ . '\enqueue_block_styles' );
+
+include_once get_parent_theme_file_path( 'inc/kindling-blocks-promoter.php' );

--- a/inc/kindling-blocks-promoter.php
+++ b/inc/kindling-blocks-promoter.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Prompt user to install Kindling Blocks when the theme is activated.
+ * 
+ * @package Kindling
+ */
+namespace Kindling;
+
+use WP_Error;
+
+if ( ! function_exists( __NAMESPACE__ . '\kindling_blocks_show_notice' ) ) :
+
+	/**
+	 * Show a persistent notice until Kindling Blocks is installed and active.
+	 * Includes a one-click install/activate flow for a private ZIP package.
+	 */
+	function kindling_blocks_show_notice() {
+		// Ensure we can check plugin status.
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		// Only show to admins who can install/activate plugins.
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			return;
+		}
+
+		$plugin_main  = 'kindling-blocks/kindling-blocks.php';
+		$is_installed = file_exists( WP_PLUGIN_DIR . '/' . $plugin_main );
+		$is_active    = function_exists( 'is_plugin_active' ) && is_plugin_active( $plugin_main );
+
+		if ( $is_active ) {
+			return; // Nothing to do.
+		}
+
+		// Message + primary action changes based on install/activate state.
+		$headline = __( 'Kindling theme is active.', 'kindling' );
+		$body     = __( 'This theme requires the Kindling Blocks plugin for full functionality.', 'kindling' );
+
+		// Private ZIP endpoint (can be a signed URL). Filterable for licensing.
+		$default_package = 'https://kindlingwp.com/plugins/kindling-blocks/latest.zip';
+		$package_url     = apply_filters( 'kindling_blocks_package_url', $default_package );
+
+		// If already installed (but inactive), offer an Activate link.
+		if ( $is_installed ) {
+			$primary_url = wp_nonce_url(
+				self_admin_url( 'plugins.php?action=activate&plugin=' . rawurlencode( $plugin_main ) ),
+				'activate-plugin_' . $plugin_main
+			);
+			$primary_label = __( 'Activate Kindling Blocks', 'kindling' );
+		} else {
+			// Point to our admin-post handler that downloads & installs from $package_url.
+			$primary_url = wp_nonce_url(
+				admin_url( 'admin-post.php?action=kindling_blocks_remote_install&pkg=' . rawurlencode( $package_url ) ),
+				'kindling_blocks_remote_install'
+			);
+			$primary_label = __( 'Install Kindling Blocks', 'kindling' );
+		}
+
+		// Secondary "Learn more / Get plugin" page on your site.
+		$learn_more_url = apply_filters( 'kindling_blocks_learn_more_url', 'https://kindlingwp.com/plugins/kindling-blocks' );
+
+		echo '<div class="notice notice-warning is-dismissible">';
+		echo '<p><strong>' . esc_html( $headline ) . '</strong> ' . esc_html( $body ) . '</p>';
+		echo '<p>';
+		echo '<a href="' . esc_url( $primary_url ) . '" class="button button-primary" style="margin-right:8px;">' . esc_html( $primary_label ) . '</a>';
+		echo '<a href="' . esc_url( $learn_more_url ) . '" class="button" target="_blank" rel="noopener noreferrer">' . esc_html__( 'Learn more', 'kindling' ) . '</a>';
+		echo '</p>';
+		echo '</div>';
+	}
+	add_action( 'admin_notices', __NAMESPACE__ . '\kindling_blocks_show_notice' );
+
+endif;
+
+if ( ! function_exists( __NAMESPACE__ . '\kindling_blocks_handle_remote_install' ) ) :
+
+	/**
+	 * Handle one-click remote install from a private ZIP, then auto-activate.
+	 * URL: /wp-admin/admin-post.php?action=kindling_blocks_remote_install&pkg=<encoded zip url>
+	 */
+	function kindling_blocks_handle_remote_install() {
+		if ( ! current_user_can( 'install_plugins' ) ) {
+			wp_die( esc_html__( 'You do not have permission to install plugins.', 'kindling' ) );
+		}
+
+		check_admin_referer( 'kindling_blocks_remote_install' );
+
+		$package = isset( $_GET['pkg'] ) ? esc_url_raw( wp_unslash( $_GET['pkg'] ) ) : '';
+		if ( empty( $package ) ) {
+			wp_safe_redirect( add_query_arg( [ 'kindling_blocks' => 'no_package' ], admin_url() ) );
+			exit;
+		}
+
+		// Load upgrader dependencies.
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/misc.php';
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		// Request filesystem creds if needed (FTP, etc.).
+		$creds = request_filesystem_credentials( admin_url(), '', false, false, null );
+		if ( false === $creds ) {
+			return; // WP will show the credentials form and re-post here.
+		}
+
+		if ( ! WP_Filesystem( $creds ) ) {
+			wp_safe_redirect( add_query_arg( [ 'kindling_blocks' => 'fs_error' ], admin_url() ) );
+			exit;
+		}
+
+		// Use a quiet skin to avoid dumping HTML into the redirect response.
+		$skin      = new \Automatic_Upgrader_Skin();
+		$upgrader  = new \Plugin_Upgrader( $skin );
+		$result    = $upgrader->install( $package );
+
+		if ( is_wp_error( $result ) ) {
+			wp_safe_redirect( add_query_arg( [ 'kindling_blocks' => 'install_error', 'msg' => rawurlencode( $result->get_error_message() ) ], admin_url( 'plugins.php' ) ) );
+			exit;
+		}
+
+		// If install succeeded, try to get the plugin file path from the result.
+		$plugin_file = '';
+		if ( ! empty( $upgrader->plugin_info() ) ) {
+			$plugin_file = $upgrader->plugin_info(); // e.g. 'kindling-blocks/kindling-blocks.php'
+		} else {
+			// Fallback to our expected main file.
+			$plugin_file = 'kindling-blocks/kindling-blocks.php';
+		}
+
+		// Activate the plugin.
+		$activate = activate_plugin( $plugin_file );
+		if ( is_wp_error( $activate ) ) {
+			wp_safe_redirect( add_query_arg( [ 'kindling_blocks' => 'activate_error', 'msg' => rawurlencode( $activate->get_error_message() ) ], admin_url( 'plugins.php' ) ) );
+			exit;
+		}
+
+		// Success — go to Plugins screen with a success param.
+		wp_safe_redirect( add_query_arg( [ 'kindling_blocks' => 'installed' ], admin_url( 'plugins.php' ) ) );
+		exit;
+	}
+	add_action( 'admin_post_kindling_blocks_remote_install', __NAMESPACE__ . '\kindling_blocks_handle_remote_install' );
+
+endif;
+
+if ( ! function_exists( __NAMESPACE__ . '\kindling_blocks_result_notice' ) ) :
+
+	/**
+	 * Optional: surface result messages after install/activate redirects.
+	 */
+	function kindling_blocks_result_notice() {
+		if ( empty( $_GET['kindling_blocks'] ) ) {
+			return;
+		}
+
+		$code = sanitize_text_field( wp_unslash( $_GET['kindling_blocks'] ) );
+		$msg  = '';
+
+		switch ( $code ) {
+			case 'installed':
+				$msg = __( 'Kindling Blocks was installed and activated successfully.', 'kindling' );
+				$cls = 'updated';
+				break;
+			case 'no_package':
+				$msg = __( 'Download URL missing for Kindling Blocks.', 'kindling' );
+				$cls = 'error';
+			 break;
+			case 'fs_error':
+				$msg = __( 'Could not initialize the filesystem API. Please try again.', 'kindling' );
+				$cls = 'error';
+				break;
+			case 'install_error':
+			case 'activate_error':
+				$err = isset( $_GET['msg'] ) ? wp_kses_post( wp_unslash( $_GET['msg'] ) ) : __( 'Unknown error.', 'kindling' );
+				$msg = sprintf( /* translators: %s: error message */ __( 'Kindling Blocks setup failed: %s', 'kindling' ), $err );
+				$cls = 'error';
+				break;
+			default:
+				return;
+		}
+
+		echo '<div class="notice ' . esc_attr( $cls ) . ' is-dismissible"><p>' . $msg . '</p></div>';
+	}
+	add_action( 'admin_notices', __NAMESPACE__ . '\kindling_blocks_result_notice' );
+
+endif;


### PR DESCRIPTION
This PR adds a lightweight, dependency-free flow in the Kindling theme that prompts admins to install and activate **Kindling Blocks**. The notice persists until the plugin is active and supports a one-click install from a private ZIP endpoint with automatic activation.

**What changed**

* Added an admin notice rendered on `admin_notices` for users who can install plugins
* If the plugin is missing, the primary action routes to an `admin-post` handler that downloads the private ZIP and runs `Plugin_Upgrader` then activates the plugin
* If the plugin is installed but inactive, the primary action activates it directly
* Added success and error result notices after redirects
* Introduced two filters for URLs:

  * `kindling_blocks_package_url` to override the ZIP location (supports signed links)
  * `kindling_blocks_learn_more_url` for a secondary link to marketing or docs

**How to test**

1. Activate Kindling on a site without Kindling Blocks.
2. Confirm the notice appears on any admin screen.
3. Click **Install Kindling Blocks**.

   * If file system creds are needed, enter them.
   * On success, confirm a success notice and that the plugin is active.
4. Deactivate the plugin and refresh.

   * Notice should reappear with **Activate** button.
   * Click **Activate** and confirm activation succeeds.
5. Override the package URL using:

   ```php
   add_filter( 'kindling_blocks_package_url', function( $url ) {
     return 'https://kindlingwp.com/plugins/kindling-blocks/signed-link.zip';
   } );
   ```

   Confirm the installer uses the new URL.

**Acceptance Criteria**

* Notice persists until the plugin is active
* Install path downloads and activates from private ZIP
* Activation path works when the plugin is installed but inactive
* Errors are surfaced in admin notices
* URLs are filterable
* Code follows WP standards and respects capabilities

**Security and privacy**

* Nonces on all actions
* `install_plugins` capability required
* Inputs sanitized and outputs escaped
* No tokens or secrets in code. Use filters for signed links

**Screenshots**

* [ ] Notice with Install button
<img width="2648" height="296" alt="image" src="https://github.com/user-attachments/assets/251f50ca-6d17-4862-b39e-db3b8372965b" />

* [ ] Notice with Activate button
<img width="2648" height="296" alt="image" src="https://github.com/user-attachments/assets/6d515b7b-7c2c-41a1-9e6f-cf3b223cabaf" />

* [ ] Success
<img width="2648" height="296" alt="image" src="https://github.com/user-attachments/assets/67fc81f0-1761-40a4-9676-eb28af254ec2" />

* [ ] Error
<img width="2648" height="400" alt="image" src="https://github.com/user-attachments/assets/9db17bcc-9609-47c2-b8bb-4c2df215fbcf" />

**Related**

* Closes: https://github.com/matchboxdesigngroup/kindling/issues/81
